### PR TITLE
Changed data ref in GetFuncInputSurrogate to return true little endian data

### DIFF
--- a/Kam1n0WinSetupProject/bin_release/plugins/Kam1n0/IDAutils.py
+++ b/Kam1n0WinSetupProject/bin_release/plugins/Kam1n0/IDAutils.py
@@ -20,6 +20,8 @@ import idc
 import idautils
 import os
 import inspect
+import binascii
+import struct
 
 ICON_SEARCH = "search"
 ICON_SEARCHMULTI = "searchs"
@@ -177,7 +179,7 @@ def GetFuncInputSurrogate(func):
             refdata = list(idautils.DataRefsFrom(head))
             if(len(refdata)>0):
                 for ref in refdata:
-                    dat[head] = format(idc.Qword(ref), 'x')[::-1]
+                    dat[head] = binascii.hexlify(struct.pack("<Q", idc.Qword(ref)))
 
         sblock['src'] = tlines
 


### PR DESCRIPTION
Hi,

I guess the 'dat' entry in the json data is not really used, because the operation that's currently there looks a bit weird to me. I guess the intention was to have 16 byte little-endian encoded data as a hex stream. This pull request should do exactly that.

If you don't mind importing the struct  and the binascii library (both are in the standard library), `binascii.hexlify(struct.pack("<Q", idc.Qword(ref)))` might be preferable to my commit.

Jonas